### PR TITLE
main.py -> c2f bin

### DIFF
--- a/main_window_ui.py
+++ b/main_window_ui.py
@@ -247,7 +247,7 @@ class MainWindow(QMainWindow):
             return
 
         # Construir comando
-        command = ["python", "main.py"]
+        command = ["Cell2Fire","--sim","S"]
         command += ["--input-instance-folder", self.input_folder_path]
         command += ["--output-folder", self.output_folder_path]
         if sim_years:
@@ -276,10 +276,6 @@ class MainWindow(QMainWindow):
             command += ["--AllowCrownFire"]
         if parallel_threads:
             command += ["--threads", parallel_threads]
-        if self.postprocessing_stats_radio.isChecked():
-            command += ["--stats"]
-        if self.postprocessing_plots_radio.isChecked():
-            command += ["--allPlots"]
 
         # Imprimir el comando
         print("Iniciando simulación con el siguiente comando:")


### PR DESCRIPTION
idea: Reemplazar main.py por llamar al binario de cell2fire-W directo.

contexto: El fork con más desarrollo de cell2fire es el de fire2a, en este integramos 3 fuel models (`--sim ...`) y botamos la interfaz de python (`main.py`) que sólo enlentencía el sistema. Si proveía algunas facilidades de gráficos (`allPlots`) que nadie mantuvo, estas quedaron obsoletas con el plugin para qgis.

otros:
- mejorar README.md, explicar que es un proyecto de QtDesigner ?
- separar al menos en 2 carpetas codigo de pruebas
- añadir `.gitignore` (al menos de python)
- borrar `__pycache__`
- especificar instalacion, modo develper y enduser. (developer al menos con `requirements.txt` y `apt install ...` también)
- especificar como integrar c2f-w (sugiero git submodule para development, y descargar un release en tu workflow de release)

- ? cómo se ejecuta la lista de comandos ?